### PR TITLE
Add copilot auto login through env vars

### DIFF
--- a/lab_notebook_intelligence/ai_service_manager.py
+++ b/lab_notebook_intelligence/ai_service_manager.py
@@ -31,18 +31,14 @@ from lab_notebook_intelligence.api import (
 )
 from lab_notebook_intelligence.base_chat_participant import BaseChatParticipant
 from lab_notebook_intelligence.config import NBIConfig
-from lab_notebook_intelligence.github_copilot_chat_participant import (
-    GithubCopilotChatParticipant,
-)
+from lab_notebook_intelligence.github_copilot_chat_participant import GithubCopilotChatParticipant
 from lab_notebook_intelligence.llm_providers.github_copilot_llm_provider import (
     GitHubCopilotLLMProvider,
 )
 from lab_notebook_intelligence.llm_providers.litellm_compatible_llm_provider import (
     LiteLLMCompatibleLLMProvider,
 )
-from lab_notebook_intelligence.llm_providers.ollama_llm_provider import (
-    OllamaLLMProvider,
-)
+from lab_notebook_intelligence.llm_providers.ollama_llm_provider import OllamaLLMProvider
 from lab_notebook_intelligence.llm_providers.openai_compatible_llm_provider import (
     OpenAICompatibleLLMProvider,
 )

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -1323,7 +1323,7 @@ function SidebarComponent(props: any) {
     }
 
     setCopilotRequestInProgress(true);
-
+    console.log('Request triggered on input - ', prompt);
     const activeDocInfo: IActiveDocumentInfo = props.getActiveDocumentInfo();
     const extractedPrompt = prompt;
     const contents: IChatMessageContent[] = [];
@@ -1362,8 +1362,6 @@ function SidebarComponent(props: any) {
         });
       }
     }
-
-    console.log('Complete context : ', additionalContext);
 
     submitCompletionRequest(
       {

--- a/src/index.ts
+++ b/src/index.ts
@@ -453,6 +453,7 @@ class NBIInlineCompletionProvider
           { chatId: this._lastRequestInfo.chatId }
         );
 
+        // TODO: handle fast-typers
         if (
           this._lastRequestInfo.completion &&
           preCursor.length > 0 &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -345,7 +345,7 @@ class NBIInlineCompletionProvider
   get schema(): ISettingRegistry.IProperty {
     return {
       default: {
-        debouncerDelay: 200,
+        debouncerDelay: 100,
         timeout: 15000
       }
     };
@@ -438,7 +438,6 @@ class NBIInlineCompletionProvider
         editorType
       }
     });
-
     return new Promise((resolve, reject) => {
       const items: IInlineCompletionItem[] = [];
 
@@ -453,11 +452,35 @@ class NBIInlineCompletionProvider
           RequestDataType.CancelInlineCompletionRequest,
           { chatId: this._lastRequestInfo.chatId }
         );
+
+        if (
+          this._lastRequestInfo.completion &&
+          preCursor.length > 0 &&
+          preCursor[preCursor.length - 1] ===
+            this._lastRequestInfo.completion[0]
+        ) {
+          // if the last element of the preCursor is the first element of the completion
+          // we do not need to make a completion request on the assumption that the
+          // user is about to type the rest of the completion
+          resolve({
+            items: [
+              { insertText: this._lastRequestInfo.completion.substring(1) }
+            ]
+          });
+          this._lastRequestInfo.completion =
+            this._lastRequestInfo.completion.substring(1);
+          return;
+        }
       }
 
       const messageId = UUID.uuid4();
       const chatId = UUID.uuid4();
-      this._lastRequestInfo = { chatId, messageId, requestTime: new Date() };
+      this._lastRequestInfo = {
+        chatId,
+        messageId,
+        completion: '',
+        requestTime: new Date()
+      };
 
       NBIAPI.inlineCompletionsRequest(
         chatId,
@@ -475,6 +498,7 @@ class NBIInlineCompletionProvider
               items.push({
                 insertText: response.data.completions
               });
+              this._lastRequestInfo.completion = response.data.completions;
 
               const timeElapsed =
                 (new Date().getTime() -
@@ -518,6 +542,7 @@ class NBIInlineCompletionProvider
   private _lastRequestInfo: {
     chatId: string;
     messageId: string;
+    completion: string;
     requestTime: Date;
   } = null;
   private _telemetryEmitter: TelemetryEmitter;
@@ -721,7 +746,7 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
         })
         .catch(reason => {
           console.error(
-            'Failed to load settings for @notebook-intelligence/lab-notebook-intelligence.',
+            'Failed to load settings for @lab-notebook-intelligence/lab-notebook-intelligence.',
             reason
           );
         });

--- a/style/base.css
+++ b/style/base.css
@@ -8,7 +8,7 @@
 .sidebar {
   display: flex;
   flex-direction: column;
-  min-width: 40%;
+  min-width: 50%;
   height: 100%;
 }
 


### PR DESCRIPTION
**Authentication and Token Management:**

* Added the `get_gh_access_token_from_env()` function in `lab_notebook_intelligence/github_copilot.py` to retrieve and decrypt the GitHub access token from the `NBI_GH_ACCESS_TOKEN_ENCRYPTED` environment variable, using a password from `NBI_GH_ACCESS_TOKEN_PASSWORD` or a default value.
* Updated `login_with_existing_credentials()` to prioritize the environment variable token and avoid storing it if present.
* Modified token retrieval logic in `get_token()` and `get_token_thread_func()` to use the environment variable token if available, falling back to the stored token otherwise. [[1]](diffhunk://#diff-bff657d28ccc1d0c813c2fdc60131904518e3518c3892866e8c90ebadd266425L334-R349) [[2]](diffhunk://#diff-bff657d28ccc1d0c813c2fdc60131904518e3518c3892866e8c90ebadd266425L396-R411)

**Inline Completion Logic Update** 
* Only trigger inline completions if the user input changes from the current completion 