### PR TITLE
Improve notebook generation capabilities

### DIFF
--- a/lab_notebook_intelligence/base_chat_participant.py
+++ b/lab_notebook_intelligence/base_chat_participant.py
@@ -493,19 +493,16 @@ class BaseChatParticipant(ChatParticipant):
 
     async def generate_title_for_notebook(self, request: ChatRequest, code: str, markdown: str) -> str:
         chat_model = request.host.chat_model
-        messages = []
-        messages.append(
+        messages = [
             {
                 "role": "system",
                 "content": f"You are an assistant that generates descriptive titles for Jupyter notebooks based on the provided code and markdown. The title should be in snake-case, concise, relevant, and accurately reflect the content of the notebook. Avoid using special characters, use '_' instead of spaces and keep it under 50 characters.",
             },
-        )
-        messages.append(
             {
                 "role": "user",
                 "content": f"Generate a descriptive title for a Jupyter notebook that contains the following markdown and code:\n\nMarkdown:\n{markdown}\n\nCode:\n{code}\n\n",
             }
-        )
+        ]
         generated = chat_model.completions(messages)
 
         # if title is too long, truncate it

--- a/lab_notebook_intelligence/base_chat_participant.py
+++ b/lab_notebook_intelligence/base_chat_participant.py
@@ -460,10 +460,10 @@ class BaseChatParticipant(ChatParticipant):
             0,
             {
                 "role": "system",
-                "content": f"You are an assistant that creates Python code which will be used in a Jupyter notebook. Generate only Python code and some comments for the code. You should return the code directly, without wrapping it inside ```.",
+                "content": f"You are an assistant that creates correct and executable Python code which will be used in a Jupyter notebook. Whenever you are using multiple libraries, ensure that the generated code is compatible and does not use deprecated or non-existent methods. Generate only Python code and some comments for the code. You should return the code directly, without wrapping it inside ```.",
             },
         )
-        messages.append({"role": "user", "content": f"Generate code for: {request.prompt}"})
+        messages.append({"role": "user", "content": f"Generate clean Python code for: {request.prompt}"})
         generated = chat_model.completions(messages)
         code = generated["choices"][0]["message"]["content"]
 
@@ -599,7 +599,7 @@ class BaseChatParticipant(ChatParticipant):
                 0,
                 {
                     "role": "system",
-                    "content": f"You are an assistant that creates Python code. You should return the code directly, without wrapping it inside ```.",
+                    "content": f"You are an assistant that creates correct and executable Python code. You should return the code directly, without wrapping it inside ```.",
                 },
             )
             messages.append({"role": "user", "content": f"Generate code for: {request.prompt}"})

--- a/lab_notebook_intelligence/extension.py
+++ b/lab_notebook_intelligence/extension.py
@@ -211,108 +211,6 @@ class MCPConfigFileHandler(APIHandler):
             return
 
 
-class CreateDynamicMCPConfigHandler(APIHandler):
-    @tornado.web.authenticated
-    def post(self):
-        try:
-            # Get the directory where JupyterLab was started (user's working directory)
-            user_root_dir = NotebookIntelligence.root_dir
-
-            print(f"Creating dynamic MCP config for directory: {user_root_dir}")
-
-            # Create dynamic MCP config with filesystem servers
-            dynamic_mcp_config = {
-                "mcpServers": {
-                    "filesystem-pwd": {
-                        "command": "npx",
-                        "args": [
-                            "-y",
-                            "@modelcontextprotocol/server-filesystem",
-                            user_root_dir,
-                        ],
-                    },
-                    "qbraid-web-search": {
-                        "command": "uv",
-                        "args": ["tool", "run", "web-browser-mcp-server"],
-                        "env": {
-                            "REQUEST_TIMEOUT": "60",
-                        },
-                    },
-                    # add the MCP server for accessing docs.qbraid.com
-                    "qbraid-docs-search": {"url": "https://docs.qbraid.com/mcp"},
-                }
-            }
-
-            # Add qBraid environments MCP server
-            qbraid_envs_dir = os.path.expanduser("~/.qbraid/environments/")
-            print(f"qBraid environments directory: {qbraid_envs_dir}")
-            if os.path.exists(qbraid_envs_dir):
-                # Add filesystem access to environments directory
-                dynamic_mcp_config["mcpServers"]["qbraid-envs"] = {
-                    "command": "npx",
-                    "args": [
-                        "-y",
-                        "@modelcontextprotocol/server-filesystem",
-                        qbraid_envs_dir,
-                    ],
-                }
-                print(f"Added qBraid environments MCP server")
-
-                # TODO: Uncomment and fix the code below to add individual Python execution servers for each qBraid environment
-
-                # # Discover individual environments and add Python execution servers
-                # try:
-                #     env_count = 0
-                #     for env_name in os.listdir(qbraid_envs_dir):
-                #         env_path = os.path.join(qbraid_envs_dir, env_name)
-                #         python_executable = os.path.join(env_path, "bin", "python")
-
-                #         # Check if this is a valid environment with Python
-                #         if (os.path.isdir(env_path) and
-                #             os.path.exists(python_executable) and
-                #             not env_name.startswith('.')):
-
-                #             # Add Python execution server for this environment
-                #             server_name = f"python-{env_name}"
-                #             dynamic_mcp_config["mcpServers"][server_name] = {
-                #                 "command": "npx",
-                #                 "args": [
-                #                     "-y",
-                #                     "@modelcontextprotocol/python-mcp"
-                #                 ],
-                #                 "env": {
-                #                     "PYTHON_EXECUTABLE": python_executable
-                #                 }
-                #             }
-                #             env_count += 1
-                #             print(f"Added Python execution server for environment: {env_name}")
-
-                #     print(f"Discovered and added {env_count} qBraid environment Python servers")
-                # except Exception as e:
-                #     print(f"Error discovering qBraid environments: {e}")
-
-            else:
-                print(f"qBraid environments directory not found: {qbraid_envs_dir}")
-
-            # Save to user's MCP config (this will merge with existing config)
-            ai_service_manager.nbi_config.user_mcp = dynamic_mcp_config
-            ai_service_manager.nbi_config.save()
-            ai_service_manager.nbi_config.load()
-            ai_service_manager.update_mcp_servers()
-
-            self.finish(
-                json.dumps(
-                    {
-                        "status": "ok",
-                        "message": f"Dynamic MCP config created for directory: {user_root_dir}",
-                    }
-                )
-            )
-        except Exception as e:
-            self.finish(json.dumps({"status": "error", "message": str(e)}))
-            return
-
-
 class EmitTelemetryEventHandler(APIHandler):
     @tornado.web.authenticated
     def post(self):
@@ -960,9 +858,6 @@ class NotebookIntelligence(ExtensionApp):
         route_pattern_mcp_config_file = url_path_join(
             base_url, "lab-notebook-intelligence", "mcp-config-file"
         )
-        route_pattern_create_dynamic_mcp_config = url_path_join(
-            base_url, "lab-notebook-intelligence", "create-dynamic-mcp-config"
-        )
         route_pattern_emit_telemetry_event = url_path_join(
             base_url, "lab-notebook-intelligence", "emit-telemetry-event"
         )
@@ -983,7 +878,6 @@ class NotebookIntelligence(ExtensionApp):
             (route_pattern_update_provider_models, UpdateProviderModelsHandler),
             (route_pattern_reload_mcp_servers, ReloadMCPServersHandler),
             (route_pattern_mcp_config_file, MCPConfigFileHandler),
-            (route_pattern_create_dynamic_mcp_config, CreateDynamicMCPConfigHandler),
             (route_pattern_emit_telemetry_event, EmitTelemetryEventHandler),
             (route_pattern_github_login_status, GetGitHubLoginStatusHandler),
             (route_pattern_github_login, PostGitHubLoginHandler),

--- a/lab_notebook_intelligence/mcp_manager.py
+++ b/lab_notebook_intelligence/mcp_manager.py
@@ -17,7 +17,6 @@ from lab_notebook_intelligence.api import (
     ChatCommand,
     ChatRequest,
     ChatResponse,
-    HTMLFrameData,
     ImageData,
     MarkdownData,
     MCPServer,

--- a/lab_notebook_intelligence/mcp_manager.py
+++ b/lab_notebook_intelligence/mcp_manager.py
@@ -31,7 +31,7 @@ log = logging.getLogger(__name__)
 MCP_ICON_SRC = "iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAIAAAAiOjnJAAAPBUlEQVR4nOydf2wT5f/AW7pZGLOjE7K5DAfWIYMWM7rpWJTZkCxEh4hdcGKahYhkYRojGPQfUnCJMRpDlpD5hyEknZlWY2AL2UaiDubYLFkDzsE2CBlBrc5ldGm6VLjdnm++6Sf77DO758fdPb279v36kzz3ft73vhfPdffjfRkIIQMAKM0ytRMAUhMQC+ACiAVwAcQCuABiAVwAsQAugFgAF0AsgAsgFsAFEAvgAogFcAHEArgAYgFcALEALoBYABdALIALIBbABRAL4AKIBXABxAK4kKF2Anrlt99+6+vru3r16s2bN+/cuTM1NRWJRGZnZ1esWGGxWPLy8mw22+bNm8vLy7dt27Zy5Uq18002RnhLh4mhoaGvvvqqo6Pjxo0blJuYzebKykq32/3qq6+uXr2ac4KaAQEUiKL4zTffVFRUyCm12Wyur6+/du2a2nuTDEAsMu3t7Xa7Xan/ySaTae/evbdu3VJ7t/gCYuG4e/duTU2NUkotJCsry+v1CoKg9i7yAsRaEr/fb7VaeVg1zzPPPDM+Pq72jnIBxEqAKIoffPABV6XmWbVqVU9Pj9p7rDwg1mIEQairq0uOVXFMJlNbW5va+60wINb/cP/+/d27dyfTqlR1C8T6L2pZNe/W2bNn1a6BYsAF0v/w4MGDvXv3tre3q5hDdnb25cuXt2zZomIOSgFiGeRYZbVan3/++a1bt27YsCE3NzcjI0MQhD/++OP69es///xzIBAQBIEpYHFxcTAYfPjhh1kz0RxqL5nqI+EMaDQa3W53V1cX/kJUOBw+derUxo0bmYIfOnQoiXvPi3QXS4JVLpdraGiIfgpBEHw+X35+Pr21vb29PHc6GaS1WKxWmc3mU6dOSZtrenra7XZTTuRwOERRVHp3k0r6isVqldVq7evrkznpsWPHKKfz+/0K7ag6pKlYEqwKBoOKTH38+HGaGe12uyLTqUU6iqWiVXEaGhpo5tX1rZ60E0t1qxBCsVhs06ZNxKk9Ho+y8yaT9BJLC1bFGRgYMBqN+NktFkssFuMxexJII7G0Y1Wc2tpaYg4XLlzglwBX0uUtHdZr61ar9fvvv9+6dSu/lN5//33imJ6eHn4JcCUt3tLhbdXc3NyPP/7Y29sbDofXr1//8ssvP/7448StysrKHA7Hr7/+ihkzMDBAmYPmUHvJ5A7vM+CtW7fKy8sXRjCZTI2Njffv3ydu6/V6icnI23vVSHGxeFs1NjZWUFCQMFRdXR1x8wsXLhBTmpyclFcDdUhlsVS0Ks63336LjzA5OUnM6pdffpFdCRVIWbFUt8pgMOzatYsYZ/ny5fggOr1MmppiacEqg8FQWFhIDEWMc/78eXnFUIcUvNzA+2/AmzdvulyuUChEHDk3N6fIGD2SamJpxyqDwUDzkHEkEsEPWLFiBWVu2kLtJVNJNHIGnOe7777DB5yYmCAGuXr1quzCqEDqXCDV1FplMBh27979yiuv4McMDw8T42RmZg4ODobD4QcPHsQfNszNzS0oKKB/JFUd1DZbGbS2VlVVVUWjUWJY4gVSDBaLZfv27UePHu3s7NTgvepUEEunViGESktLJUm1GIvF8vrrr2vqwoTuxdKvVcFgUJJFODZt2nTmzBktNLHRt1j6tQoh5PF4JMlDprS09NKlS1KLqgw6FkvXVgUCAZPJJEkbWt54443p6Wmp1ZWLXsXStVWCIDgcDkm2sFFcXKzWrUZdiqVrqxBCjY2NkjyRgsViUaXXiP7E0rtVH3/8sSRDpKNKjySdiaV3qz755BNJbsgl+W7pSSywSg4mk+ncuXOSCi8F3YiV5lZlZ2c/9thjhYWFFotFThCmdiZy0IdY6WmV0+lsamq6dOnS1NTUwmhTU1M9PT1er/epp55ijblhw4ZIJMJSe4noQKx0s8poNHo8HsqlJRAI1NbWMl0SS07/La2LlW5WlZeXS/gmSiAQoL8wlpz+W5oWK92sOnz4sOTbfLFY7ODBg5QTlZaW8u6/pV2x0soqo9HY0tIiqU7/w4cffkg5I+/+WxoVK92sOn36tKQ6JYDSLYfDodSMCdGiWGCVTCjPifIbFGLQnFhglXwo+2/V19crPvU82hILrFKKvr4+Yv+tnJwcmgYT0tCQWGCVstD03/rhhx84za4VscAqxbl8+TIxk2PHjnGaXRNigVUY4p+j3rFjR35+fkFBQXV1Nf3zVU888QQ+merqavpMmFBfLLAKQzQafeGFF/4dp7a2lubnEfFznvn5+fTJMKGyWGAVhmg0WlVVtVS0t956ixihs7OTmBWn5+LVFAuswoC3Kh6Q+Cl8mve2b9y4QZ8VPaqJBVZhIFoV5+TJk/g4oihmZmbig3C6TKqOWGAVBkqrDAbDkSNHiNGIH+Ln9P60CmKBVRjorTIYDCdOnCAGfOSRR/BBUkQssAoDk1U0ToiiSHwGMBVOhWAVBlarKioqiDHv3r1LjKP7H+9gFQZWq4qKisbHx4lhz58/TwzF6RH4JIkFVmHgZBVC6OjRo/hQ+r5AClZh4GcVQqi4uBgfbefOnfSpMsFdLLAKA1er+vv7iQG9Xi99tkzwFQuswsDVKoRQwpuMi+DXRoujWGAVBt5W9fb2EmPm5OTw6/3HSyywCgNvq6LR6JNPPkkMe+DAAfqYrHARC6zCwNsqhND+/ftpIvf39zOFZUJ5sQRB2LNnD33hWK0aHx8HqzBQtvguKytjCsuK8mIx9S5ntWpqaqqoqIg+Pli1FLy//aSwWNPT01lZWZT7xmqVIAgul4v+wIBVS8F7uVJerO7ubsp9k/CN+BMnTtAfGLBqKUwmE9dfV3EUFuvMmTM0+ybBqmvXrtE36wGrMLz99ttMwaWhwoolwSpBEMrKyigLB1Zh2LhxI1NxJKOwWJFIJCcnB7NjEqxCCPl8PsrCgVUYLBYLp4dk/o3yfxVi2k1Ls0oQBJvNRlM4sAqDyWTq7Oxkii8HLtex9u3b9+8dy8vLk2AVQujs2bM0hausrASrliJ12nH7fD6n0xnvS5GXl3fo0KFQKCQt1I4dO4iFKywsnJiYoI8JVvGG79MNsVgsHA7LiRAKhWj+GOzq6qKPCVYlAfVfscfT0tJCrJ3b7aYPCFYlB62LVVNTQ6zdyMgIZTSwKmloWixRFFetWoUvH32/FLAqmWharJGREWIFfT4fTSiwKsloWqxz584Ri0jzxyBYlXw0LdZnn32GL6LNZiMG+fTTT+mPClilFJoW68iRI/g6vvjii/gIXV1dxB6v84BVCqJpsYj9yg8ePIiP4HQ6KY8KWKUsmharvr4eX83GxkbM5jSdC+KAVYqjabGILwU0NDRgNqd5BQqs4oSmxXrnnXfwNa2trcVsPjw8TDwqYBUnNC1WU1MTvqxbtmzBbC6KYn5+PmZzsIofmhbryy+/xFc2MzNzZmYGE+HkyZNglSpoWqwrV64Q69vd3Y2JIIpiXV1dwqMCVnFF02LNzMwQm/7u378fH0QQhObm5oXnRKfTyfQNGbBKApoWCyFUUVGBr3J2dva9e/eIcURRHB0dvXLlCuvzhmCVNLQuFk3R+X1pCKySjNbFCgaDxHJnZWXdvn1b8anBKjloXSyEEM3HQquqqpRt9QRWyUQHYmEuGSzk3XffVWpGsEo+OhDr3r17+Jdg51Gko2YkEgGr5KMDsZiOxOHDh+WcE0Oh0NNPPw1WyUcfYk1PT+Nvzixk+/btxO+tJaS9vZ1+FrAKjz7EYmrfEP878b333qN/hXVoaIipCyFYRUQ3YiGEdu3axXTss7KyPB5PR0fHUq/eh0KhL774wuVy0T9lClZRYvx/uXTC33//7XQ6f//9d9YNMzMzS0pKbDbbmjVrMjIyYrHYn3/+OTo6eufOHQlpFBUVXbx4cd26dfSbHD9+nL5rnMlkam1tfe211yTkpiHUNpuN/v7+5cuXq1guWKso0ZlYCCG/30/f2k9ZwCp69CcWQqitrS35boFVTOhSrPi6lcxzYnFxMVjFhF7FQggNDAwUFhby1Ok/VFdXszZjSnOr9C0WQmhiYoLYjkYOZrP5o48+EkWRKSuwSvdixWlra1uzZo3iVj377LPDw8OsyYBVcVJBrPjzCF6v12q1KqKU3W73+/2sCxVYtZAUEStONBptbm622+3SfDIajTU1NR0dHRKUAqsWkVJizRMMBpuamiorK81mM/EYW63WPXv2tLS0/PXXX5JnBKsWoadbOhL4559/RkdHr1+/HgqFJiYmZmZmYrHYypUrLRbLo48+un79+s2bN69bt27ZsmVyZknHOzZE1DZb98BalRAQSxZg1VKAWNIBqzCAWBIBq/CAWFIAq4iAWMyAVTSAWGyAVZSAWAyAVfSAWLSAVUyAWFSAVayAWGTAKgmAWAQoW5KAVYtI8ZvQMvnpp59cLpcoijSD0+XuMh0g1pLMzs7a7faxsTGawWDVImQ9LpLanD59GqySDKxYS1JSUjI6OkocBlYlBFasxIyMjIBVcgCxEnPx4kXiGLAKA4iVGOLnqMEqPCBWYiYnJ/ED3G43WIUBxErM3NwcfsDq1auTlYsuAbESk5ubix/g8/kGBgaSlY7+ALESY7PZ8AOi0ejOnTvBraUAsRLz3HPPEcdEIhFwayngAmli5ubm1q5dGwqFiCMtFkt3d/e2bduSkpdugBUrMcuWLXvzzTdpRsK6lRBYsZYkHA7bbLZwOEwzGNatRcCKtSRWq7W5uZlyMKxbiwCxcHg8ngMHDlAOBrcWAqdCArOzsx6P5+uvv6YcD+fEOLBiEcjIyGhtbU34KfyEwLoVB8QiA25JAMSiAtxiBX5jMSDh91ZfX5/D4eCclxYBsdhgdcvpdA4ODnJOSovAqZAN1nNiMBgEsQAqWN0KBAKcM9IiIJYUmNwSBIF/RpoDxJIIvVslJSVJyUhbwI93WRB/yxcUFNy+fVvdr8KqAqxYssCvW0aj8fPPP09Dq0AsBYi71dDQsOjfs7OzW1tbX3rpJZXyUhk4FSrG4OCg3+8fGxt76KGHysvL9+3bt3btWrWTUg0QC+ACnAoBLoBYABdALIALIBbABRAL4AKIBXABxAK4AGIBXACxAC6AWAAXQCyACyAWwAUQC+ACiAVwAcQCuABiAVz4vwAAAP//b8cbMGXTzMEAAAAASUVORK5CYII="
 MCP_ICON_URL = f"data:image/png;base64,{MCP_ICON_SRC}"
 MCP_TOOL_TIMEOUT = 60
-WHITELISTED_MCP_TOOLS = {"SearchQBraid"}
+WHITELISTED_MCP_TOOLS = {"resolve-library-id", "get-library-docs"}
 
 
 class MCPTool(Tool):
@@ -263,6 +263,12 @@ class MCPChatParticipant(BaseChatParticipant):
     async def handle_chat_request(
         self, request: ChatRequest, response: ChatResponse, options: dict = {}
     ) -> None:
+        self._current_chat_request = request
+
+        # Auto-detect libraries in the query and fetch documentation
+        await self._auto_fetch_library_docs(request, response)
+        log.info("Completed auto-fetch library docs check")
+
         response.stream(ProgressData("Thinking..."))
 
         if request.command == "info":
@@ -300,6 +306,13 @@ class MCPManager:
             participant_servers = self.create_servers(server_names, servers_config)
 
             if len(participant_servers) > 0:
+                # Auto-add the library docs tool if context7 tools are available
+                if (
+                    self._has_context7_tools(participant_servers)
+                    and "auto_library_docs" not in nbi_tools
+                ):
+                    nbi_tools.append("auto_library_docs")
+
                 self._mcp_participants.append(
                     MCPChatParticipant(
                         f"mcp-{participant_id}",
@@ -326,6 +339,11 @@ class MCPManager:
             unused_servers = self.create_servers(unused_server_names, servers_config)
             mcp_participant_config = participants_config.get("mcp", {})
             nbi_tools = mcp_participant_config.get("nbiTools", [])
+
+            # Auto-add the library docs tool if context7 tools are available
+            if self._has_context7_tools(unused_servers) and "auto_library_docs" not in nbi_tools:
+                nbi_tools.append("auto_library_docs")
+
             self._mcp_participants.append(
                 MCPChatParticipant("mcp", "MCP", unused_servers, nbi_tools)
             )
@@ -333,6 +351,20 @@ class MCPManager:
 
         thread = threading.Thread(target=self.init_tool_lists, args=())
         thread.start()
+
+    def _has_context7_tools(self, servers: list[MCPServer]) -> bool:
+        """Check if any server has both resolve-library-id and get-library-docs tools"""
+        has_resolve = False
+        has_docs = False
+
+        for server in servers:
+            server_tools = [tool.name for tool in server.get_tools()]
+            if "resolve-library-id" in server_tools:
+                has_resolve = True
+            if "get-library-docs" in server_tools:
+                has_docs = True
+
+        return has_resolve and has_docs
 
     def create_servers(self, server_names: list[str], servers_config: dict):
         servers = []

--- a/lab_notebook_intelligence/prompts.py
+++ b/lab_notebook_intelligence/prompts.py
@@ -27,7 +27,7 @@ You can answer general programming questions and perform the following tasks:
 * Ask how to do something in the terminal
 * Explain what just happened in the terminal
 You use the {MODEL_NAME} AI model provided by {MODEL_PROVIDER}.
-If there is any mention of "qbraid", in any capitalization, or related terms you should use the external MCP tool called "qbraid-docs-search".
+If there is any mention of "qbraid", in any capitalization, or related terms you should use the external MCP tool called "context7-search".
 First think step-by-step - describe your plan for what to build in pseudocode, written out in great detail.
 Then output the code in a single code block. This code block should not contain line numbers (line numbers are not necessary for the code to be understood, they are in format number: at beginning of lines).
 Minimize any other prose.
@@ -38,6 +38,39 @@ The user works in an IDE called {IDE_NAME} which has a concept for editors with 
 The user is working on a {OS_TYPE} machine. Please respond with system specific commands if applicable.
 The active document is the source code the user is looking at right now.
 You can only give one reply for each conversation turn.
+"""
+
+CONTEXT_DOCS_IDENTIFICATION_PROMPT = """
+Analyze the following user query and determine if it would benefit from Python library documentation or platform-specific documentation.
+
+User Query: "{USER_QUERY}"
+
+Respond with a JSON object containing:
+1. "needs_docs": boolean - true if the query is asking about Python libraries, packages, platforms, or programming concepts that would benefit from documentation
+2. "libraries": array of strings - **ONLY** specific Python library/package names mentioned (e.g., ["pandas", "numpy", "qiskit", "braket", "qbraid"])
+3. "search_terms": array of strings - You can include strings which are required for this search e.g. "runtime", "quantum computing", "machine learning", etc.
+
+**Examples:**
+
+Query: "How can I submit a braket circuit to a qiskit backend using qbraid runtime?"
+Response: {{"needs_docs": true, "libraries": ["braket", "qiskit", "qbraid"], "search_terms": ["braket", "qiskit", "qbraid"]}}
+
+Query: "What do you know about qbraid runtime?"
+Response: {{"needs_docs": true, "libraries": ["qbraid"], "search_terms": ["qbraid"]}}
+
+Query: "How to use numpy arrays?"
+Response: {{"needs_docs": true, "libraries": ["numpy"], "search_terms": ["numpy"]}}
+
+Query: "I'm getting an error with pandas DataFrame"
+Response: {{"needs_docs": true, "libraries": ["pandas"], "search_terms": ["pandas"]}}
+
+Query: "How do I plot data?"
+Response: {{"needs_docs": true, "libraries": [], "search_terms": ["matplotlib", "plotly", "seaborn"]}}
+
+Query: "What's the weather today?"
+Response: {{"needs_docs": false, "libraries": [], "search_terms": []}}
+
+Only respond with the JSON object, no other text:
 """
 
 
@@ -61,3 +94,7 @@ class Prompts:
             MODEL_NAME=model_name,
             MODEL_PROVIDER=model_provider,
         )
+
+    @staticmethod
+    def library_detection_prompt(user_query: str) -> str:
+        return CONTEXT_DOCS_IDENTIFICATION_PROMPT.format(USER_QUERY=user_query)

--- a/lab_notebook_intelligence/prompts.py
+++ b/lab_notebook_intelligence/prompts.py
@@ -5,7 +5,7 @@ IDE_NAME = "JupyterLab"
 OS_TYPE = "Linux"
 
 CHAT_SYSTEM_PROMPT = """
-You are an AI programming assistant.
+You are an AI programming assistant for qBraid jupyter lab users.
 When asked for your name, you must respond with "{AI_ASSISTANT_NAME}".
 Follow the user's requirements carefully & to the letter.
 Follow Microsoft content policies.
@@ -27,6 +27,7 @@ You can answer general programming questions and perform the following tasks:
 * Ask how to do something in the terminal
 * Explain what just happened in the terminal
 You use the {MODEL_NAME} AI model provided by {MODEL_PROVIDER}.
+If there is any mention of "qbraid", in any capitalization, or related terms you should use the external MCP tool called "qbraid-docs-search".
 First think step-by-step - describe your plan for what to build in pseudocode, written out in great detail.
 Then output the code in a single code block. This code block should not contain line numbers (line numbers are not necessary for the code to be understood, they are in format number: at beginning of lines).
 Minimize any other prose.

--- a/src/api.ts
+++ b/src/api.ts
@@ -288,22 +288,6 @@ export class NBIAPI {
     });
   }
 
-  static async createDynamicMCPConfig(): Promise<any> {
-    return new Promise<any>((resolve, reject) => {
-      requestAPI<any>('create-dynamic-mcp-config', {
-        method: 'POST',
-        body: JSON.stringify({})
-      })
-        .then(async data => {
-          resolve(data);
-        })
-        .catch(reason => {
-          console.error(`Failed to create dynamic MCP config.\n${reason}`);
-          reject(reason);
-        });
-    });
-  }
-
   static async chatRequest(
     messageId: string,
     chatId: string,

--- a/src/chat-sidebar.tsx
+++ b/src/chat-sidebar.tsx
@@ -761,7 +761,6 @@ function SidebarComponent(props: any) {
     const uniqueFiles = Array.from(new Set(finalFiles));
     setSelectedFiles(uniqueFiles);
     setShowFileBrowser(false);
-    console.log(`Selected files: ${filePaths}`);
   };
 
   const handleContextCancel = () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -983,7 +983,7 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
 
           try {
             await app.serviceManager.contents.rename(oldPath, newPath);
-            return 'Successfully renamed notebook';
+            return { newPath: newPath };
           } catch (error) {
             return `Failed to rename notebook: ${error}`;
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,8 @@ namespace CommandIDs {
 
 const DOCUMENT_WATCH_INTERVAL = 1000;
 const MAX_TOKENS = 4096;
+const STREAM_TOKEN_DELAY = 75; // milliseconds
+const STREAM_TOKEN_LEN = 20; // characters
 const githubCopilotIcon = new LabIcon({
   name: 'lab-notebook-intelligence:github-copilot-icon',
   svgstr: copilotSvgstr
@@ -1051,11 +1053,24 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
       const newCellIndex = isNewEmptyNotebook(model)
         ? 0
         : model.cells.length - 1;
+
       model.insertCell(newCellIndex, {
         cell_type: cellType,
         metadata: { trusted: true },
-        source
+        source: ''
       });
+
+      const cell = currentWidget.content.widgets[newCellIndex];
+      let currentText = '';
+      (async () => {
+        for (let i = 0; i < source.length; i += STREAM_TOKEN_LEN) {
+          currentText += source.slice(i, i + STREAM_TOKEN_LEN);
+          cell.model.sharedModel.source = currentText;
+          // Wait for a short delay to simulate streaming
+          // eslint-disable-next-line no-await-in-loop
+          await new Promise(resolve => setTimeout(resolve, STREAM_TOKEN_DELAY));
+        }
+      })();
 
       return true;
     };
@@ -1123,12 +1138,27 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
         const newCellIndex = isNewEmptyNotebook(model)
           ? 0
           : model.cells.length - 1;
+
         model.insertCell(newCellIndex, {
           cell_type: 'markdown',
           metadata: { trusted: true },
-          source: args.source as string
+          source: ''
         });
 
+        const sourceStr = args.source as string;
+        const cell = np.content.widgets[newCellIndex];
+        let currentText = '';
+        (async () => {
+          for (let i = 0; i < sourceStr.length; i += STREAM_TOKEN_LEN) {
+            currentText += sourceStr.slice(i, i + STREAM_TOKEN_LEN);
+            cell.model.sharedModel.source = currentText;
+            // Wait for a short delay to simulate streaming
+            // eslint-disable-next-line no-await-in-loop
+            await new Promise(resolve =>
+              setTimeout(resolve, STREAM_TOKEN_DELAY)
+            );
+          }
+        })();
         return true;
       }
     });
@@ -1145,11 +1175,27 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
         const newCellIndex = isNewEmptyNotebook(model)
           ? 0
           : model.cells.length - 1;
+
         model.insertCell(newCellIndex, {
           cell_type: 'code',
           metadata: { trusted: true },
-          source: args.source as string
+          source: ''
         });
+
+        const sourceStr = args.source as string;
+        const cell = np.content.widgets[newCellIndex];
+        let currentText = '';
+        (async () => {
+          for (let i = 0; i < sourceStr.length; i += STREAM_TOKEN_LEN) {
+            currentText += sourceStr.slice(i, i + STREAM_TOKEN_LEN);
+            cell.model.sharedModel.source = currentText;
+            // Wait for a short delay to simulate streaming
+            // eslint-disable-next-line no-await-in-loop
+            await new Promise(resolve =>
+              setTimeout(resolve, STREAM_TOKEN_DELAY)
+            );
+          }
+        })();
 
         return true;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -725,15 +725,6 @@ const plugin: JupyterFrontEndPlugin<INotebookIntelligence> = {
 
     await NBIAPI.initialize();
 
-    // Create dynamic MCP config after API is initialized
-    console.log('Creating dynamic MCP config...');
-    try {
-      await NBIAPI.createDynamicMCPConfig();
-      console.log('Dynamic MCP config created successfully!');
-    } catch (error) {
-      console.error('Failed to create dynamic MCP config:', error);
-    }
-
     let openPopover: InlinePromptWidget | null = null;
     let mcpConfigEditor: MCPConfigEditor | null = null;
 


### PR DESCRIPTION
## Summary 

**Backend enhancements:**

* Improved the system prompt for code generation to require correct, executable, and compatible Python code, especially when using multiple libraries, and to avoid deprecated or non-existent methods. The user prompt now requests "clean Python code" for clarity. [[1]](diffhunk://#diff-89c9ad3356c0f9f1ea9897924575cd346cfe02a2e759abaf6961ada463961462L463-R466) [[2]](diffhunk://#diff-89c9ad3356c0f9f1ea9897924575cd346cfe02a2e759abaf6961ada463961462L564-R599)
* Added a new `generate_title_for_notebook` method to automatically generate descriptive, snake-case notebook titles based on the generated code and markdown. The method ensures title uniqueness and length constraints, and integrates this into the notebook creation flow so new notebooks are named meaningfully. [[1]](diffhunk://#diff-89c9ad3356c0f9f1ea9897924575cd346cfe02a2e759abaf6961ada463961462R494-R521) [[2]](diffhunk://#diff-89c9ad3356c0f9f1ea9897924575cd346cfe02a2e759abaf6961ada463961462L553-R588)

**Prompt and context improvements:**

* Updated the main chat system prompt to clarify that the assistant is for qBraid JupyterLab users, and instructs the assistant to use the "qbraid-docs-search" tool when qBraid or related terms are mentioned. [[1]](diffhunk://#diff-5e85394c6e7f3da495b82a93613171cb6d8e5da30c5dbbf6dfb09142c439a022L8-R8) [[2]](diffhunk://#diff-5e85394c6e7f3da495b82a93613171cb6d8e5da30c5dbbf6dfb09142c439a022R30)

**Frontend (UI/UX) improvements:**

* Implemented streaming of notebook cell content (both code and markdown) as it is generated, by progressively updating the cell's content in chunks with a short delay between updates. This provides a more interactive and responsive experience for users as they see content appear in real time. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R1056-R1074) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R1141-R1161) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R1178-R1198)

